### PR TITLE
Fix links to journal home pages

### DIFF
--- a/_journals/archaeology_international.md
+++ b/_journals/archaeology_international.md
@@ -2,7 +2,7 @@
 title: Archaeology International
 model: diamond
 peer_reviewed: yes
-url: https://journals.uclpress.co.uk/ai/
+website: https://journals.uclpress.co.uk/ai/
 issn: 2048-4194
 publisher: UCL Press
 languages:

--- a/_journals/archeologia_e_calcolatori.md
+++ b/_journals/archeologia_e_calcolatori.md
@@ -2,7 +2,7 @@
 title: Archeologia e Calcolatori
 model: diamond
 peer_reviewed: true
-url: https://www.archcalc.cnr.it/
+website: https://www.archcalc.cnr.it/
 issn: 1120-6861
 publisher: Consiglio Nazionale delle Ricerche
 languages:

--- a/_journals/danish_journal_of_archaeology.md
+++ b/_journals/danish_journal_of_archaeology.md
@@ -2,7 +2,7 @@
 title: Danish Journal of Archaeology
 model: diamond
 peer_reviewed: true
-url: https://tidsskrift.dk/dja/index
+website: https://tidsskrift.dk/dja/index
 issn: 2166-2290
 publisher: National Museum of Denmark
 languages:

--- a/_journals/gallia_préhistoire.md
+++ b/_journals/gallia_préhistoire.md
@@ -2,7 +2,7 @@
 title: Gallia Préhistoire
 model: diamond
 peer_reviewed: true
-url: https://journals.openedition.org/galliap/
+website: https://journals.openedition.org/galliap/
 issn: 2109-9642
 publisher: CNRS Editions
 languages:

--- a/_journals/journal_of_neolithic_archaeology.md
+++ b/_journals/journal_of_neolithic_archaeology.md
@@ -2,7 +2,7 @@
 title: Journal of Neolithic Archaeology
 model: diamond
 peer_reviewed: true
-url: http://www.jungsteinsite.de/
+website: http://www.jungsteinsite.de/
 issn: 2197-649X
 publisher: Kiel University
 languages:

--- a/_journals/mesolithic_miscellany.md
+++ b/_journals/mesolithic_miscellany.md
@@ -2,7 +2,7 @@
 title: Mesolithic Miscellany
 model: diamond
 peer_reviewed: false
-url: https://sites.google.com/site/mesolithicmiscellany
+website: https://sites.google.com/site/mesolithicmiscellany
 issn: 0259-3548
 languages:
 - en

--- a/_journals/neo-lithics.md
+++ b/_journals/neo-lithics.md
@@ -2,7 +2,7 @@
 title: Neo-Lithics
 model: diamond
 peer_reviewed: false
-url: https://journals.ub.uni-heidelberg.de/index.php/nl/index
+website: https://journals.ub.uni-heidelberg.de/index.php/nl/index
 issn: 2750-2910
 publisher: ex oriente
 languages:

--- a/_journals/paléorient.md
+++ b/_journals/paléorient.md
@@ -2,7 +2,7 @@
 title: Paléorient
 model: diamond
 peer_reviewed: true
-url: https://journals.openedition.org/paleorient/
+website: https://journals.openedition.org/paleorient/
 issn: 1957-701X
 publisher: CNRS Editions
 languages:

--- a/_journals/primitive_tider.md
+++ b/_journals/primitive_tider.md
@@ -2,7 +2,7 @@
 title: Primitive Tider
 model: diamond
 peer_reviewed: true
-url: https://journals.uio.no/PT
+website: https://journals.uio.no/PT
 issn: 2535-6194
 publisher: University of Oslo
 languages:

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -26,7 +26,7 @@ layout: base
       <tr>
         <td>
           <cite>
-            <a href="{{ journal.url }}" title="{{ journal.title }} home page">
+            <a href="{{ journal.website }}" title="{{ journal.title }} home page">
               {{ journal.title }}
             </a>
           </cite>


### PR DESCRIPTION
Fixes the links to the journals on the home page by renaming the `url` field (which has a special value in Jekyll) to `website`.